### PR TITLE
Add a building configuration parameter ENABLE_GNUTLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ option(ENABLE_STRIP "Create stripped binaries without debugging symbols (in Rele
 
 option(Boost_USE_STATIC_LIBS "Use Boost static libs" OFF)
 
+option(ENABLE_GNUTLS "Forces linking against GnuTLS" OFF)
+
 if(ENABLE_PACKAGING)
     set(ENABLE_ARMA_NO_DEBUG ON)
     set(CMAKE_VERBOSE_MAKEFILE ON)
@@ -3472,6 +3474,7 @@ add_feature_info(ENABLE_OWN_GLOG ENABLE_OWN_GLOG "Forces the downloading and bui
 add_feature_info(ENABLE_GLOG_AND_GFLAGS ENABLE_GLOG_AND_GFLAGS "Forces the usage of Google glog and Gflags instead of Abseil.")
 add_feature_info(ENABLE_OWN_ABSEIL ENABLE_OWN_ABSEIL "Forces downloading and building Abseil. Supersedes ENABLE_OWN_GLOG.")
 add_feature_info(ENABLE_OWN_ARMADILLO ENABLE_OWN_ARMADILLO "Forces the downloading and building of Armadillo.")
+add_feature_info(ENABLE_GNUTLS ENABLE_GNUTLS "Forces linking against GnuTLS instead of OpenSSL.")
 add_feature_info(ENABLE_LOG ENABLE_LOG "Enables runtime internal logging.")
 add_feature_info(ENABLE_ORC ENABLE_ORC "Use the Optimized Inner Loop Runtime Compiler (ORC) for building volk_gnsssdr.")
 add_feature_info(ENABLE_STRIP ENABLE_STRIP "Enables the generation of stripped binaries (without debugging symbols).")

--- a/cmake/Modules/GnssSdrCrypto.cmake
+++ b/cmake/Modules/GnssSdrCrypto.cmake
@@ -11,7 +11,11 @@
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(OPENSSL_ROOT_DIR /usr/local/opt/openssl) # Trick for Homebrew
 endif()
-find_package(OpenSSL)
+unset(OPENSSL_FOUND CACHE)
+unset(GnuTLS_FOUND CACHE)
+if(NOT ENABLE_GNUTLS)
+    find_package(OpenSSL)
+endif()
 set_package_properties(OpenSSL
     PROPERTIES
         URL "https://www.openssl.org"
@@ -162,7 +166,6 @@ function(link_to_crypto_dependencies target)
                     target_compile_definitions(${target} PUBLIC -DUSE_OPENSSL_111=1)
                 endif()
             endif()
-        else()
         endif()
     else()  # GnuTLS
         target_link_libraries(${target}


### PR DESCRIPTION
Add a building configuration parameter `-DENABLE_GNUTLS`, by default to `OFF`, to allow the user to link against GnuTLS instead of OpenSSL.
